### PR TITLE
Dev wlc getallmovies

### DIFF
--- a/client/src/components/AddMovieButton/index.js
+++ b/client/src/components/AddMovieButton/index.js
@@ -8,7 +8,7 @@ import { Link as RouterLink } from 'react-router-dom';
 
 export default function BasicCard() {
     return (
-        <RouterLink to="/AddMovie">
+        <RouterLink to="/AddMovie" style={{ textDecoration: 'none' }}>
             <Card sx={{ minWidth: 275 }}>
                 <CardActionArea>
                     <CardContent sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/client/src/components/DashCard/index.js
+++ b/client/src/components/DashCard/index.js
@@ -9,7 +9,7 @@ import { Link as RouterLink } from 'react-router-dom';
 
 export default function BasicCard(props) {
     return (
-        <RouterLink to={`/movieDetails/:${props._id}`} style={{ textDecoration: 'none' }}>
+        <RouterLink to={`/movieDetails/${props._id}`} style={{ textDecoration: 'none' }}>
             <Card sx={{ minWidth: 275 }}>
                 <CardActionArea>
                     <CardContent>

--- a/client/src/components/DashCard/index.js
+++ b/client/src/components/DashCard/index.js
@@ -6,18 +6,18 @@ import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 
 
-export default function BasicCard() {
+export default function BasicCard(props) {
     return (
         <Card sx={{ minWidth: 275 }}>
             <CardContent>
                 <Typography variant="h5" component="div">
-                    Title
+                    {props.title}
                 </Typography>
-                <Typography sx={{ mb: 1.5 }} color="text.secondary">
+                {/* <Typography sx={{ mb: 1.5 }} color="text.secondary">
                     subtitle
-                </Typography>
+                </Typography> */}
                 <Typography variant="body2">
-                    Hook Question
+                    {props.hookQuestion}
                 </Typography>
             </CardContent>
             <CardContent>

--- a/client/src/components/DashCard/index.js
+++ b/client/src/components/DashCard/index.js
@@ -4,45 +4,50 @@ import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
-
+import CardActionArea from '@mui/material/CardActionArea';
+import { Link as RouterLink } from 'react-router-dom';
 
 export default function BasicCard(props) {
     return (
-        <Card sx={{ minWidth: 275 }}>
-            <CardContent>
-                <Typography variant="h5" component="div">
-                    {props.title}
-                </Typography>
-                {/* <Typography sx={{ mb: 1.5 }} color="text.secondary">
-                    subtitle
-                </Typography> */}
-                <Typography variant="body2">
-                    {props.hookQuestion}
-                </Typography>
-            </CardContent>
-            <CardContent>
-                <Stack direction="row" justifyContent="center" spacing={1}>
-                    <Paper sx={{ p: 2 }}  elevation={3} >
-                        <Typography variant="body2">
-                            Seen It
+        <RouterLink to={`/movieDetails/:${props._id}`} style={{ textDecoration: 'none' }}>
+            <Card sx={{ minWidth: 275 }}>
+                <CardActionArea>
+                    <CardContent>
+                        <Typography variant="h5" component="div">
+                            {props.title}
                         </Typography>
+                        {/* <Typography sx={{ mb: 1.5 }} color="text.secondary">
+                            subtitle
+                        </Typography> */}
                         <Typography variant="body2">
-                            {props.seenPercent}%
+                            {props.hookQuestion}
                         </Typography>
-                    </Paper>
-                    <Paper sx={{ p: 2 }} elevation={3} >
-                        <Typography variant="body2">
-                            {props.lovedItCount} out of {props.ratingTotal}
-                        </Typography>
-                        <Typography variant="body2">
-                            Fanz
-                        </Typography>
-                        <Typography variant="body2">
-                            Loved It!
-                        </Typography>
-                    </Paper>
-                </Stack>
-            </CardContent>
-        </Card>
+                    </CardContent>
+                    <CardContent>
+                        <Stack direction="row" justifyContent="center" spacing={1}>
+                            <Paper sx={{ p: 2 }}  elevation={3} >
+                                <Typography variant="body2">
+                                    Seen It
+                                </Typography>
+                                <Typography variant="body2">
+                                    {props.seenPercent}%
+                                </Typography>
+                            </Paper>
+                            <Paper sx={{ p: 2 }} elevation={3} >
+                                <Typography variant="body2">
+                                    {props.lovedItCount} out of {props.ratingTotal}
+                                </Typography>
+                                <Typography variant="body2">
+                                    Fanz
+                                </Typography>
+                                <Typography variant="body2">
+                                    Loved It!
+                                </Typography>
+                            </Paper>
+                        </Stack>
+                    </CardContent>
+                </CardActionArea>
+            </Card>
+        </RouterLink>
     );
 }

--- a/client/src/components/DashCard/index.js
+++ b/client/src/components/DashCard/index.js
@@ -24,12 +24,21 @@ export default function BasicCard(props) {
                 <Stack direction="row" justifyContent="center" spacing={1}>
                     <Paper sx={{ p: 2 }}  elevation={3} >
                         <Typography variant="body2">
-                            Rating 1
+                            Seen It
+                        </Typography>
+                        <Typography variant="body2">
+                            {props.seenPercent}%
                         </Typography>
                     </Paper>
                     <Paper sx={{ p: 2 }} elevation={3} >
                         <Typography variant="body2">
-                            Rating 2
+                            {props.lovedItCount} out of {props.ratingTotal}
+                        </Typography>
+                        <Typography variant="body2">
+                            Fanz
+                        </Typography>
+                        <Typography variant="body2">
+                            Loved It!
                         </Typography>
                     </Paper>
                 </Stack>

--- a/client/src/components/ResponsiveDrawer/index.js
+++ b/client/src/components/ResponsiveDrawer/index.js
@@ -71,7 +71,7 @@ function ResponsiveDrawer(props) {
       <Divider />
       <List sx={{ mt: 6 }}>
         {buttonSet1.map((navButton, index) => (
-          <Link to={navButton.link} key={navButton.text}>
+          <Link to={navButton.link} key={navButton.text} style={{ textDecoration: 'none' }}>
             <ListItem button >
               <ListItemIcon>
                 {navButton.icon}
@@ -86,7 +86,7 @@ function ResponsiveDrawer(props) {
 
       {Auth.loggedIn() ? (
         <>
-          <Link to='/' key='Logout' onClick={Auth.logout}>
+          <Link to='/' key='Logout' onClick={Auth.logout} style={{ textDecoration: 'none' }}>
             <ListItem button >
               <ListItemIcon>
                 <InboxIcon />
@@ -97,7 +97,7 @@ function ResponsiveDrawer(props) {
         </>
       ) : (
         <>
-          <Link to='/login' key='Login/Sign Up'>
+          <Link to='/login' key='Login/Sign Up' style={{ textDecoration: 'none' }}>
             <ListItem button >
               <ListItemIcon>
                 <InboxIcon />
@@ -180,6 +180,7 @@ function ResponsiveDrawer(props) {
             <Route exact path='/login' component={Login} />
             <Route exact path='/signup' component={Signup} />
             <Route exact path='/AddMovie' component={AddMovie} />
+            <Route exact path='/movieDetails/:movieId' component={Home} />
             <Route path='/' component={Home} />
           </Switch>
 

--- a/client/src/components/ResponsiveDrawer/index.js
+++ b/client/src/components/ResponsiveDrawer/index.js
@@ -30,6 +30,7 @@ import Signup from '../../pages/Signup';
 import AddMovie from '../../pages/AddMovie';
 
 import Auth from '../../utils/auth';
+import MovieDetails from '../../pages/MovieDetails';
 
 const drawerWidth = 240;
 
@@ -180,7 +181,7 @@ function ResponsiveDrawer(props) {
             <Route exact path='/login' component={Login} />
             <Route exact path='/signup' component={Signup} />
             <Route exact path='/AddMovie' component={AddMovie} />
-            <Route exact path='/movieDetails/:movieId' component={Home} />
+            <Route exact path='/movieDetails/:movieId' component={MovieDetails} />
             <Route path='/' component={Home} />
           </Switch>
 

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -34,7 +34,11 @@ const Dashboard = () => {
                     <>
                         {allMovies.map((movie) => (
                             <Grid item key={movie._id}>
-                                <DashCard movie={movie}/>
+                                <DashCard 
+                                    _id={movie._id}
+                                    title={movie.title}
+                                    hookQuestion={movie.hookQuestions[0].questionText}
+                                />
                             </Grid>
                         ))}
                     </>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box';
 import { useQuery } from '@apollo/client';
 import { GET_MOVIES } from '../utils/queries';
 import { Typography } from '@mui/material';
+import { percent, total } from '../utils/helpers';
 
 const Dashboard = () => {
     const { loading, data } = useQuery( GET_MOVIES );
@@ -38,6 +39,9 @@ const Dashboard = () => {
                                     _id={movie._id}
                                     title={movie.title}
                                     hookQuestion={movie.hookQuestions[0].questionText}
+                                    seenPercent={percent(movie.seenItCount, movie.notSeenItCount)}
+                                    lovedItCount={movie.lovedItCount}
+                                    ratingTotal={total(movie.lovedItCount, movie.hatedItCount)}
                                 />
                             </Grid>
                         ))}

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -4,8 +4,15 @@ import AddMovieButton from '../components/AddMovieButton';
 import Container from '@mui/material/Container';
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
+import { useQuery } from '@apollo/client';
+import { GET_MOVIES } from '../utils/queries';
+import { Typography } from '@mui/material';
 
 const Dashboard = () => {
+    const { loading, data } = useQuery( GET_MOVIES );
+
+    const allMovies = data?.getMovies || [];
+
     return (
         <Container sx={{mt: 3}}>
             <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
@@ -17,15 +24,21 @@ const Dashboard = () => {
                 <Grid item>
                     <AddMovieButton />
                 </Grid>
-                {/* Testing larger collections */}
-                {Array.from(Array(8)).map((_, index) => (
+                {loading ? (
                     <Grid item>
-                        <DashCard />
+                        <Typography variant="h5" component="div">
+                            LOADING...
+                        </Typography>
                     </Grid>
-                ))}
-                {/* <Grid item>
-                    <DashCard />
-                </Grid> */}
+                ) : (
+                    <>
+                        {allMovies.map((movie) => (
+                            <Grid item key={movie._id}>
+                                <DashCard movie={movie}/>
+                            </Grid>
+                        ))}
+                    </>
+                )}
             </Grid>
         </Container>
     );

--- a/client/src/pages/MovieDetails.js
+++ b/client/src/pages/MovieDetails.js
@@ -8,14 +8,12 @@ import { Container, Typography } from '@mui/material';
 
 const MovieDetails = () => {
 	const { movieId } = useParams();
-    console.log("~ movieId", movieId);
 
 	const { loading, data } = useQuery(GET_MOVIE_BY_ID, {
 		variables: {
 			id: movieId
 		}
 	});
-	console.log("~ data", data);
 
 	const movieData = data?.getMovieById || {}
 

--- a/client/src/pages/MovieDetails.js
+++ b/client/src/pages/MovieDetails.js
@@ -1,0 +1,50 @@
+import { useQuery } from '@apollo/client';
+import Grid from '@mui/material/Grid';
+import DashCard from '../components/DashCard';
+import { useParams } from 'react-router';
+import { GET_MOVIE_BY_ID } from '../utils/queries';
+import { percent, total } from '../utils/helpers';
+import { Container, Typography } from '@mui/material';
+
+const MovieDetails = () => {
+	const { movieId } = useParams();
+    console.log("~ movieId", movieId);
+
+	const { loading, data } = useQuery(GET_MOVIE_BY_ID, {
+		variables: {
+			id: movieId
+		}
+	});
+	console.log("~ data", data);
+
+	const movieData = data?.getMovieById || {}
+
+	return (
+        <Container sx={{mt: 3}}>
+            <Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+				{loading ? (
+						<Grid item>
+							<Typography variant="h5" component="div">
+								LOADING...
+							</Typography>
+						</Grid>
+					) : (
+						<>
+							<Grid item key={movieData._id}>
+								<DashCard
+									_id={movieData._id}
+									title={movieData.title}
+									hookQuestion={movieData.hookQuestions[0].questionText}
+									seenPercent={percent(movieData.seenItCount, movieData.notSeenItCount)}
+									lovedItCount={movieData.lovedItCount}
+									ratingTotal={total(movieData.lovedItCount, movieData.hatedItCount)}
+								/>
+							</Grid>
+						</>
+					)}
+			</Grid>
+		</Container>
+	);
+};
+
+export default MovieDetails;

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -1,0 +1,7 @@
+export const percent = (num1, num2) => {
+	return parseInt((num1/(num1 + num2)) * 100);
+};
+
+export const total = (num1, num2) => {
+	return num1 + num2;
+}

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -8,5 +8,22 @@ export const GET_ME = gql`
     }
 `
 
-//GET_MOVIES
+export const GET_MOVIES = gql`
+    query getMovies {
+        _id
+        title
+        description
+        seenItCount
+        notSeenItCount
+        lovedItCount
+        hatedItCount
+        hookQuestions {
+            _id
+            questionText
+            movieId
+            userId
+        }
+    }
+`
+
 //GET_HOOKQUESTIONS

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -10,18 +10,20 @@ export const GET_ME = gql`
 
 export const GET_MOVIES = gql`
     query getMovies {
-        _id
-        title
-        description
-        seenItCount
-        notSeenItCount
-        lovedItCount
-        hatedItCount
-        hookQuestions {
+        getMovies {
             _id
-            questionText
-            movieId
-            userId
+            title
+            description
+            seenItCount
+            notSeenItCount
+            lovedItCount
+            hatedItCount
+            hookQuestions {
+                _id
+                questionText
+                movieId
+                userId
+            }
         }
     }
 `

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -28,4 +28,21 @@ export const GET_MOVIES = gql`
     }
 `
 
+export const GET_MOVIE_BY_ID = gql`
+    query getMovieByID($id: ID!) {
+        getMovieById(id: $id) {
+            _id
+            title
+            seenItCount
+            notSeenItCount
+            lovedItCount
+            hatedItCount
+            description
+            hookQuestions {
+                questionText
+            }
+        }
+    }
+`
+
 //GET_HOOKQUESTIONS

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -14,7 +14,7 @@ const resolvers = {
             throw new AuthenticationError('You need to be logged in first.')
         },
 
-        getAllMovies: async () => {
+        getMovies: async () => {
             return await Movie.find().populate( 'hookQuestions' );
         },
 

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -14,6 +14,10 @@ const resolvers = {
             throw new AuthenticationError('You need to be logged in first.')
         },
 
+        getAllMovies: async () => {
+            return await Movie.find().populate( 'hookQuestions' );
+        },
+
         getMovieById: async (parent, {id}) => {
 
             try {

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -36,7 +36,7 @@ const typeDefs = gql`
 
         me: User
 
-        getAllMovies: [Movie]
+        getMovies: [Movie]
 
         getMovieById(id: ID): Movie
 

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -36,6 +36,8 @@ const typeDefs = gql`
 
         me: User
 
+        getAllMovies: [Movie]
+
         getMovieById(id: ID): Movie
 
         getMovieByTitle(title: String): Movie

--- a/server/seeds/movieData.json
+++ b/server/seeds/movieData.json
@@ -2,68 +2,84 @@
     {
         "title": "Repo the Genetic Opera",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
-        "lovedItCount": 0,
-        "hatedItCount": 0,
-        "hookQuestions": []
-
-
+        "seenItCount": 2,
+        "notSeenItCount": 8,
+        "lovedItCount": 1,
+        "hatedItCount": 1,
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     },
 
     {
         "title": "Flight of the Navigator",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
-        "lovedItCount": 0,
-        "hatedItCount": 0,
-        "hookQuestions": []
+        "seenItCount": 5,
+        "notSeenItCount": 5,
+        "lovedItCount": 4,
+        "hatedItCount": 1,
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     },
 
     {
         "title": "The Last Dragon",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
-        "lovedItCount": 0,
-        "hatedItCount": 0,
-        "hookQuestions": []
-
-
+        "seenItCount": 7,
+        "notSeenItCount": 3,
+        "lovedItCount": 3,
+        "hatedItCount": 4,
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     },
 
     {
         "title": "The Wiz",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
-        "lovedItCount": 0,
-        "hatedItCount": 0,
-        "hookQuestions": []
-
-
+        "seenItCount": 9,
+        "notSeenItCount": 1,
+        "lovedItCount": 7,
+        "hatedItCount": 2,
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     },
 
     {
         "title": "The Red Violin",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
-        "lovedItCount": 0,
+        "seenItCount": 4,
+        "notSeenItCount": 6,
+        "lovedItCount": 4,
         "hatedItCount": 0,
-        "hookQuestions": []
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     },
 
     {
         "title": "One Hour Photo",
         "description": "URL or API image",
-        "seenItCount": 0,
-        "notSeenItCount": 0,
+        "seenItCount": 1,
+        "notSeenItCount": 9,
         "lovedItCount": 0,
-        "hatedItCount": 0,
-        "hookQuestions": []
-
-
+        "hatedItCount": 1,
+        "hookQuestions": [
+            {
+                "questionText": "Testing the hook questions"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This branch handles the full run through of creating resolvers to get all movies and get movies by ID to having our seeded data display on each card in the collection and each of those being a link to their specific movie detail page. 

- getMovies query in typeDef
- getMovies and getMoviesById resolvers
- GET_MOVIES and GET_MOVIE_BY_ID query client side
- Expanded seed data to have testing hook question and numbers for likes, seen it, etc.
- Seeded data queried to movie cards on dashboard
- Created some helper functions to get totals and percentages for likes and seen it rating
- Cards wrapped in router link and navigate to MovieDetail page 
- MovieDetail pages query GET_MOVIE_BY_ID passing in id with url params
- Also eliminated the pesky underline on all links

Next tasks to assign:
- refine styles on cards
- Build out full MoviesDetail page component (currently substituted with a single card from dashboard)